### PR TITLE
Use main.cpp as Doxygen landing page. Fixes #14

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,5 +1,4 @@
 # Doxyfile 1.9.1
-
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
 #
@@ -12,6 +11,7 @@
 # For lists, items can also be appended using:
 # TAG += value [value, ...]
 # Values that contain spaces should be placed between quotes (\" \").
+# TODO: #14 Use main.cpp for the landing page for Doxygen online docs.
 
 #---------------------------------------------------------------------------
 # Project related configuration options
@@ -864,7 +864,8 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./README.md 
+INPUT                  = ./src/ \
+                         ./lib/ 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1068,7 +1069,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ./README.md
+USE_MDFILE_AS_MAINPAGE = 
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/lib/aaSocMicro/aaSocMicro.cpp
+++ b/lib/aaSocMicro/aaSocMicro.cpp
@@ -260,7 +260,7 @@ void aaSocMicro::_logCoreCPU()
  * cache for this external memory.
  * – Supports up to 16 MB off-Chip SPI Flash.
  * – Supports up to 8 MB off-Chip SPI SRAM.
- * See https://blog.espressif.com/esp32-programmers-memory-model-259444d89387
+ * TODO: #11 See https://blog.espressif.com/esp32-programmers-memory-model-259444d89387
  * for further breakdown of SRAM, IRAM, DRAM. Also investigate SOC_IRAM, 
  * SOC_DRAM, SOC_RTC high/low syntax.
  * ============================================================================*/


### PR DESCRIPTION
Updated the INPUT and USE_MDFILE_AS_MAINPAGE fields in Doxyfile to drop README.md and added @mainpage tag to comment block at the top of main.cpp.