### PR TITLE
Remove ascii banner from Doxygen main page

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -490,7 +490,7 @@ EXTRACT_ALL            = NO
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PRIV_VIRTUAL tag is set to YES, documented private virtual
 # methods of a class will be included in the documentation.

--- a/lib/aaSocMicro/aaSocMicro.cpp
+++ b/lib/aaSocMicro/aaSocMicro.cpp
@@ -48,10 +48,10 @@ aaSocMicro::aaSocMicro(Print *output)
 /**
  * @brief This is the third constructor form for this class.
  * @details Instantiating this class using the third form results in you
- * controlling all logging behavior for this class.
- * @param loggingLevel is one of 6 predefined levels from the logging library.
+ * controlling all Logging behavior for this class.
+ * @param loggingLevel is one of 6 predefined levels from the Logging library.
  * @param output class that handles bit stream input.
- * @param showLevel when true prefixs log message with the logging level letter.
+ * @param showLevel when true prefixs log message with the Logging level letter.
  * @return null
  ******************************************************************************/
 aaSocMicro::aaSocMicro(int loggingLevel, Print *output, bool showLevel)

--- a/src/main.dox
+++ b/src/main.dox
@@ -1,6 +1,4 @@
-/**
- @mainpage <a href="https://github.com/theAgingApprentice/icUnderware">icUderwear</a> Robot projects start here! 
- 
+/*
  d8b          888     888               888                                                           
  Y8P          888     888               888                                                           
               888     888               888                                                           
@@ -9,7 +7,11 @@
  888 888      888     888 888  888 888  888 88888888 888     888  888  888 .d888888 888     88888888  
  888 Y88b.    Y88b. .d88P 888  888 Y88b 888 Y8b.     888     Y88b 888 d88P 888  888 888     Y8b.      
  888  "Y8888P  "Y88888P"  888  888  "Y88888  "Y8888  888      "Y8888888P"  "Y888888 888      "Y8888   
-                                                                                                       
+*/
+
+/**
+ @mainpage <a href="https://github.com/theAgingApprentice/icUnderware">icUnderwear</a> Robot projects start here! 
+                                                                                                     
  Overview
  ========
   


### PR DESCRIPTION
Fixes #29 and also chnages the EXTRACT_PRIVATE parameter in Doxyfile from NO to YES so that private classes are listed in the online documentation.